### PR TITLE
Add unitrace conditional collection support

### DIFF
--- a/run.py
+++ b/run.py
@@ -11,6 +11,7 @@ Wall time provided for sanity but is not a sane benchmark measurement.
 
 import argparse
 import time
+import os
 from functools import partial
 
 import numpy as np
@@ -232,12 +233,17 @@ def run_one_step(
             # Collect time_ns() instead of time() which does not provide better precision than 1
             # second according to https://docs.python.org/3/library/time.html#time.time.
             with context_func(args.profile_test, args.model, args.test, args.device, 'none', 'yes') as prof:
+                # Unitrace conditional collection: only collect last iteration
+                if os.environ.get("UNITRACE_LAST_ITER") and _i == num_iter - 1:
+                    os.environ["PTI_ENABLE_COLLECTION"] = "1"
                 t0 = time.time_ns()
                 #start_event.record()
                 func()
                 #end_event.record()
                 torch.xpu.synchronize()
                 t1 = time.time_ns()
+                if os.environ.get("UNITRACE_LAST_ITER") and _i == num_iter - 1:
+                    os.environ["PTI_ENABLE_COLLECTION"] = "0"
                 result_summary.append(
                     #(start_event.elapsed_time(end_event), (t1 - t0) / 1_000_000)
                     ((t1 - t0) / 1_000_000, (t1 - t0) / 1_000_000)


### PR DESCRIPTION
## Summary

- Adds unitrace conditional collection to `run.py` for clean single-iteration XPU kernel tracing
- When `UNITRACE_LAST_ITER=1` is set, enables `PTI_ENABLE_COLLECTION` only on the last benchmark iteration
- Used with `unitrace --start-paused` to capture exactly one iteration without cross-iteration kernel leakage

## Usage

```bash
UNITRACE_LAST_ITER=1 \
  unitrace --chrome-kernel-logging --start-paused \
  python run.py <model> -d xpu --precision fp16 --channels-last --bs <bs> --test eval
```

## Why

Without conditional collection, unitrace captures all iterations. The GPU runs continuously with no clean gaps between iterations, making it impossible to reliably isolate a single iteration by timestamp slicing. This caused bugs where kernel sum > E2E time due to kernels from adjacent iterations leaking into the measurement window.

This patch was previously applied as a local modification on each machine. Upstreaming it eliminates the need for per-machine patching.