### PR TITLE
Support timm models outside of timm_models_list.txt

### DIFF
--- a/torchbenchmark/__init__.py
+++ b/torchbenchmark/__init__.py
@@ -651,14 +651,14 @@ def load_model_by_name(model_name: str):
             list_extended_huggingface_models,
         )
         from torchbenchmark.util.framework.timm.extended_configs import (
-            list_extended_timm_models,
+            is_extended_timm_models,
         )
 
         if model_name in list_extended_huggingface_models():
             cls_name = "ExtendedHuggingFaceModel"
             module_path = ".util.framework.huggingface.model_factory"
             models.append(model_name)
-        elif model_name in list_extended_timm_models():
+        elif is_extended_timm_models(model_name):
             cls_name = "ExtendedTimmModel"
             module_path = ".util.framework.timm.model_factory"
             models.append(model_name)

--- a/torchbenchmark/util/framework/timm/extended_configs.py
+++ b/torchbenchmark/util/framework/timm/extended_configs.py
@@ -25,8 +25,23 @@ with open(MODELS_FILENAME) as fh:
         TIMM_MODELS[model_name] = int(batch_size)
 
 
+# Batch size for timm models that are not listed in timm_models_list.txt
+DEFAULT_TIMM_BATCH_SIZE = 128
+
+
 def is_extended_timm_models(model_name: str) -> bool:
-    return model_name in TIMM_MODELS
+    if model_name in TIMM_MODELS:
+        return True
+    try:
+        import timm
+    except ImportError:
+        return False
+    # Also accepts names carrying a pretrained tag, e.g. deit_tiny_patch16_224.fb_in1k
+    return timm.is_model(model_name)
+
+
+def get_timm_batch_size(model_name: str) -> int:
+    return TIMM_MODELS.get(model_name, DEFAULT_TIMM_BATCH_SIZE)
 
 
 def list_extended_timm_models() -> List[str]:

--- a/torchbenchmark/util/framework/timm/model_factory.py
+++ b/torchbenchmark/util/framework/timm/model_factory.py
@@ -5,7 +5,7 @@ import timm
 import torch
 from torchbenchmark.util.model import BenchmarkModel
 
-from .extended_configs import BATCH_SIZE_DIVISORS, TIMM_MODELS
+from .extended_configs import BATCH_SIZE_DIVISORS, get_timm_batch_size
 from .timm_config import TimmConfig
 
 # No pretrained weights exist for specific TIMM models
@@ -143,7 +143,7 @@ class ExtendedTimmModel(TimmModel):
     ]
 
     def __init__(self, test, device, batch_size=None, extra_args=[]):
-        recorded_batch_size = TIMM_MODELS[self.name]
+        recorded_batch_size = get_timm_batch_size(self.name)
         if self.name in BATCH_SIZE_DIVISORS:
             recorded_batch_size = max(
                 int(recorded_batch_size / BATCH_SIZE_DIVISORS[self.name]), 1


### PR DESCRIPTION
## Problem

Running any timm model that is not in the hardcoded whitelist fails:

```
Error: The model deit_tiny_patch16_224.fb_in1k cannot be found at either core or canary model set
```

`load_model_by_name()` resolves extended timm models by checking membership in `TIMM_MODELS`, which is parsed from `userbenchmark/dynamo/dynamobench/timm_models_list.txt` — a fixed 60-entry list synced from dynamo bench. Names valid to timm but absent from that file (including anything carrying a pretrained tag, e.g. `.fb_in1k`) fall through to the canary lookup and error out.

The whitelist also doubles as the batch-size table, so `ExtendedTimmModel.__init__` would hit a `KeyError` on `TIMM_MODELS[self.name]` even if the lookup were bypassed.

## Change

- `is_extended_timm_models()` falls back to `timm.is_model()` when the name is not in the whitelist. `timm.is_model()` handles pretrained tags, so `deit_tiny_patch16_224.fb_in1k` resolves.
- New `get_timm_batch_size()` returns the recorded batch size for whitelisted models and `DEFAULT_TIMM_BATCH_SIZE = 128` otherwise.
- `load_model_by_name()` uses `is_extended_timm_models()` instead of the list membership test.

Whitelisted models keep their recorded batch sizes and `BATCH_SIZE_DIVISORS` overrides. Names unknown to timm still raise `ModelNotFoundError`.

## Verification

Ran on cpu, `bs=2`, timm 1.0.27:

| model | eval | train |
|---|---|---|
| `convnextv2_nano.fcmae_ft_in22k_in1k` | PASS | PASS |
| `deit_tiny_patch16_224.fb_in1k` | PASS | PASS |
| `vit_base_patch14_dinov2.lvd142m` | PASS | see below |
| `vit_base_patch16_siglip_256.v2_webli` | PASS | see below |

Regression checks:

- `lcnet_050` (whitelisted) still resolves with `DEFAULT_EVAL_BSIZE=256`
- `definitely_not_a_model_xyz` still raises `ModelNotFoundError`

## Known limitations (out of scope)

**Train on headless backbones.** `vit_base_patch14_dinov2` and `vit_base_patch16_siglip_256` are feature extractors with `num_classes=0`, so `TimmConfig.num_classes` is 0 and `_gen_target()` fails with `RuntimeError: random_ expects 'from' to be less than 'to', but got from=0 >= to=0`. This is independent of the change here — every model in the existing whitelist has a classifier head, so the path was never exercised. Inference is what we need for now; train support for headless backbones can be added separately.

**Hub-style repo ids.** `timm/deit_tiny_patch16_224.fb_in1k` is still unsupported — `timm.is_model()` rejects the `timm/` prefix, and `timm.create_model()` expects either the bare name or an `hf_hub:` prefix.
