### PR TITLE
Add new extended timm models to timm_models_list.txt

### DIFF
--- a/userbenchmark/dynamo/dynamobench/timm_models_list.txt
+++ b/userbenchmark/dynamo/dynamobench/timm_models_list.txt
@@ -6,9 +6,11 @@ coat_lite_mini 128
 convit_base 128
 convmixer_768_32 64
 convnext_base 128
+convnextv2_nano.fcmae_ft_in22k_in1k 128
 crossvit_9_240 256
 cspdarknet53 128
 deit_base_distilled_patch16_224 128
+deit_tiny_patch16_224.fb_in1k 128
 dla102 128
 dm_nfnet_f0 128
 dpn107 64
@@ -56,6 +58,8 @@ tinynet_a 128
 tnt_s_patch16_224 128
 twins_pcpvt_base 128
 visformer_small 128
+vit_base_patch14_dinov2.lvd142m 128
 vit_base_patch16_224 128
+vit_base_patch16_siglip_256 128
 volo_d1_224 128
 xcit_large_24_p8_224 16


### PR DESCRIPTION
## Problem

Running any of the following models fails before the model is even built:

```
$ python run.py convnextv2_nano.fcmae_ft_in22k_in1k -d xpu --precision fp16 --channels-last --bs 1
Error: The model convnextv2_nano.fcmae_ft_in22k_in1k cannot be found at either core or canary model set.
```

Same for `vit_base_patch16_siglip_256`, `vit_base_patch14_dinov2.lvd142m` and `deit_tiny_patch16_224.fb_in1k`.

## Root cause

These models have no dedicated script under `torchbenchmark/models/`; they are meant to be resolved through the **extended timm** path.

`load_model_by_name()` in `torchbenchmark/__init__.py` first matches against the core model directories, and on a miss falls back to `list_extended_timm_models()`, dynamically binding `ExtendedTimmModel` + `timm.create_model(name)`.

That list is built from `userbenchmark/dynamo/dynamobench/timm_models_list.txt` using an **exact string match** — the pretrained-tag suffix (`.fcmae_ft_in22k_in1k`, `.fb_in1k`, `.lvd142m`) is not normalized. Upstream `pytorch/benchmark` has added these entries; our copy of the file predates that, so lookup fails and `ModelNotFoundError` is raised.

## Fix

Add the four missing entries (batch size `128`, matching upstream):

| model | bs |
|---|---|
| `convnextv2_nano.fcmae_ft_in22k_in1k` | 128 |
| `deit_tiny_patch16_224.fb_in1k` | 128 |
| `vit_base_patch14_dinov2.lvd142m` | 128 |
| `vit_base_patch16_siglip_256` | 128 |

Entries are **appended** instead of syncing the whole file from upstream: upstream trimmed its list down to ~18 models, dropping `convnext_base`, `beit_base_patch16_224`, `xcit_large_24_p8_224` and many others that are still covered here. A wholesale replacement would silently shrink our benchmark coverage.

No changes were needed in `extended_configs.py` or `model_factory.py` — both already match upstream.

## Validation

`torch 2.14.0.dev+xpu`, `timm 1.0.22`, eval / fp16 / channels-last / bs=1 on XPU:

| model | GPU time per batch |
|---|---|
| `convnextv2_nano.fcmae_ft_in22k_in1k` | 4.068 ms |
| `vit_base_patch16_siglip_256` | 4.275 ms |
| `vit_base_patch14_dinov2.lvd142m` | 6.555 ms |
| `deit_tiny_patch16_224.fb_in1k` | 3.389 ms |

> Note: these models require `timm >= 1.0` (older timm does not know the `convnextv2` / `siglip` / `dinov2` pretrained tags).
